### PR TITLE
Allow for optionally passing a --flat flag to vue-gettext-extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ manifest.json
 ./coverage
 
 .tm_properties
+.idea/

--- a/scripts/gettext_extract.js
+++ b/scripts/gettext_extract.js
@@ -23,6 +23,12 @@ if (localesIndex > -1) {
 }
 locales = locales.split(",").map((l) => l.trim());
 
+const flatIndex = process.argv.indexOf("--flat");
+let flat = false;
+if (flatIndex > -1) {
+  flat = true;
+}
+
 const potPath = `${outDir}/messages.pot`;
 console.log(`Source directory directory: ${srcDir}`);
 console.log(`Output directory: ${srcDir}`);
@@ -57,11 +63,12 @@ function execShellCommand(cmd) {
   console.log(extracted);
 
   locales.forEach(async (loc) => {
-    const poDir = `${outDir}/${loc}/`;
+    const poDir = flat ? `${outDir}/` : `${outDir}/${loc}/`;
+
     try {
       fs.writeFileSync(potPath, "", { flag: "wx" });
     } catch {}
-    const poFile = `${poDir}app.po`;
+    const poFile = flat ? `${poDir}${loc}.po` : `${poDir}app.po`;
     fs.mkdirSync(poDir, { recursive: true });
     const isFile = fs.existsSync(poFile) && fs.lstatSync(poFile).isFile();
     if (isFile) {


### PR DESCRIPTION
If this is optional flag is passed, the .po files are created directly at the --out directory, with the language as the file name.

This differs from the current behavior as it does not create a folder with an app.po file for each language.

The result of passing the flag looks like this:
```
language
├── en_GB.po
├── fr_FR.po
├── it_IT.po
├── messages.pot
└── translations.json
```

Without passing, it this is the result:
```
language
├── en_GB
│   └── app.po
├── fr_FR
│   └── app.po
├── it_IT
│   └── app.po
├── messages.pot
└── translations.json
```