### PR TITLE
Feature: Output a LINGUAS file during extraction step?

### DIFF
--- a/dev/language/LINGUAS
+++ b/dev/language/LINGUAS
@@ -1,0 +1,1 @@
+en_GB fr_FR it_IT

--- a/scripts/gettext_extract.js
+++ b/scripts/gettext_extract.js
@@ -56,19 +56,13 @@ function execShellCommand(cmd) {
   const extracted = await execShellCommand(
     `gettext-extract --attribute v-translate --output ${potPath} ${files.split("\n").join(" ")}`,
   );
-  try {
-    fs.writeFileSync(potPath, "", { flag: "wx" });
-  } catch {}
   fs.chmodSync(potPath, 0o666);
   console.log(extracted);
 
-  locales.forEach(async (loc) => {
+  for (const loc of locales) {
     const poDir = flat ? `${outDir}/` : `${outDir}/${loc}/`;
-
-    try {
-      fs.writeFileSync(potPath, "", { flag: "wx" });
-    } catch {}
     const poFile = flat ? `${poDir}${loc}.po` : `${poDir}app.po`;
+
     fs.mkdirSync(poDir, { recursive: true });
     const isFile = fs.existsSync(poFile) && fs.lstatSync(poFile).isFile();
     if (isFile) {
@@ -78,5 +72,6 @@ function execShellCommand(cmd) {
       fs.chmodSync(poFile, 0o666);
       await execShellCommand(`msgattrib --no-wrap --no-obsolete -o ${poFile} ${poFile}`);
     }
-  });
+  }
+  fs.writeFileSync(`${outDir}/LINGUAS`, locales.join(" "));
 })();


### PR DESCRIPTION
This file is specified to contain the list of available translations.

More here:
https://www.gnu.org/software/gettext/manual/html_node/po_002fLINGUAS.html

Additionally, the two `messages.pot` writeFileSync calls were removed. This file is added also when both calls are removed, and both calls errors out due to the "wx" flag failing if the path exists. Even when initially manually removing the file, this error occurs.

Lastly, the forEach iteration for the locales is replaced with a `for of ` loop as the promise returned in the forEach is not used.

If adjusting the catch blocks to print out the error if caught, below message is shown.
```javascript
try {
    fs.writeFileSync(potPath, "", { flag: "wx" });
} catch(error) {
    console.error(error);
}
```

```log
Error: EEXIST: file already exists, open './dev/language/messages.pot'
    at Object.openSync (node:fs:585:3)
    at Object.writeFileSync (node:fs:2153:35)
    at /home/olof/git/vue3-gettext/scripts/gettext_extract.js:70:10
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  errno: -17,
  syscall: 'open',
  code: 'EEXIST',
  path: './dev/language/messages.pot'
}
```