### PR TITLE
Handle evaluated being null as well

### DIFF
--- a/src/interpolate.ts
+++ b/src/interpolate.ts
@@ -69,7 +69,7 @@ const interpolate =
         } catch (e) {
           // Ignore errors, because this function may be called recursively later.
         }
-        if (evaluated === undefined) {
+        if (evaluated === undefined || evaluated === null) {
           if (parent) {
             // Recursively climb the parent chain to allow evaluation inside nested components, see #23 and #24.
             return evalInContext(parent.ctx, expression, parent.parent);


### PR DESCRIPTION
Otherwise we get `TypeError: evaluated is null` when calling evaluated.toString() below in case the translation isn't available.

There's possibly better ways to fix this.