### PR TITLE
Augment "vue" module instead of "@vue/runtime-core"

### DIFF
--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -91,7 +91,7 @@ export interface GettextConfigOptions {
   output?: Partial<GettextConfig["output"]>;
 }
 
-declare module "@vue/runtime-core" {
+declare module "vue" {
   interface ComponentCustomProperties extends Pick<Language, "$gettext" | "$pgettext" | "$ngettext" | "$npgettext"> {
     $gettextInterpolate: Language["interpolate"];
   }


### PR DESCRIPTION
When using a package manager stricter than npm [such as pnpm](https://pnpm.io/motivation#creating-a-non-flat-node_modules-directory), `@vue/runtime-core` is not directly accessible and therefore cannot be augmented.

This contribution updates the module augmentation to use `vue` (which is what this package define as a peer dependency). This is also what the [current Vue documentation suggests to use ](https://vuejs.org/api/utility-types.html#componentcustomproperties).




Thanks for providing this library!