### PR TITLE
feat: Add option to compile template before extracting

### DIFF
--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -65,6 +65,7 @@ module.exports = {
         },
       },
     ],
+	compileTemplate: false, // do not compile <template> tag when its lang is not html
   },
   output: {
     path: "./src/language", // output path of all created files

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -32,6 +32,7 @@ export const loadConfig = (cliArgs?: { config?: string }): GettextConfig => {
       include: config.input?.include || ["**/*.js", "**/*.ts", "**/*.vue"],
       exclude: config.input?.exclude || [],
       jsExtractorOpts: config.input?.jsExtractorOpts,
+      compileTemplate: config.input?.compileTemplate || false,
     },
     output: {
       path: languagePath,

--- a/scripts/extract.ts
+++ b/scripts/extract.ts
@@ -1,4 +1,4 @@
-import { parse } from "@vue/compiler-sfc";
+import { parse, compileTemplate } from "@vue/compiler-sfc";
 import chalk from "chalk";
 import fs from "fs";
 import { GettextExtractor, HtmlExtractors, JsExtractors } from "gettext-extractor";
@@ -98,6 +98,21 @@ const extractFromFiles = async (filePaths: string[], potPath: string, config: Ge
         if (descriptor.template) {
           htmlParser.parseString(descriptor.template.content, descriptor.filename, {
             lineNumberStart: descriptor.template.loc.start.line,
+            transformSource: (code) => {
+              const lang = descriptor?.template?.lang?.toLowerCase() || "html";
+              if (!config.input?.compileTemplate || lang === "html") {
+                return code;
+              }
+
+              const compiledTemplate = compileTemplate({
+                filename: descriptor?.filename,
+                source: code,
+                preprocessLang: lang,
+                id: descriptor?.filename,
+              });
+
+              return compiledTemplate.source;
+            },
           });
         }
         if (descriptor.script) {

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -88,6 +88,7 @@ export interface GettextConfig {
       keyword: string;
       options: IJsExtractorOptions;
     }[];
+    compileTemplate: boolean;
   };
   output: {
     path: string;


### PR DESCRIPTION
This PR fixes the issue when extract script cannot parse strings like in example below. 

```vue
<template lang="pug">
.not-found-page
	.not-found-page__text.content
		h1.content__title {{ $gettext('Page not found') }}
		p.content__subtitle {{ $gettext('Sorry, we couldn\'t find the page you\'re looking for.') }}
		img.content__image(
			:src="image.src",
			:alt="$gettext('Just an example of using gettext in pug template')",
		)
	// ...
</template>
```

This PR fixes this behavior, but numbers of parsed lines in *.po files will always be 1 for compiled templates. Fixing this is out of scope of the feature. That's why I've added an option `compileTemplate` to enable my fix.

If you have any suggestions or questions — feel free to ask!

P.S. Thank you for the project!