### PR TITLE
Fix extracted line numbers

### DIFF
--- a/scripts/attributeEmbeddedJsExtractor.ts
+++ b/scripts/attributeEmbeddedJsExtractor.ts
@@ -6,17 +6,20 @@ export function attributeEmbeddedJsExtractor(selector: string, jsParser: JsParse
   Validate.required.nonEmptyString({ selector });
   Validate.required.argument({ jsParser });
 
-  return (node: any, fileName: string, _, lineNumberStart) => {
+  return (node: any, fileName: string, _, nodeLineNumberStart) => {
     if (typeof (node as Element).tagName !== "string") {
       return;
     }
 
     const element = node as Element;
     element.attrs.forEach((attr) => {
-      const startLine = element.sourceCodeLocation?.attrs[attr.name]?.startLine;
-      if (startLine) {
-        lineNumberStart = lineNumberStart + startLine - 1;
+      let lineNumberStart = nodeLineNumberStart;
+      const attributeLineNumber = element.sourceCodeLocation?.attrs[attr.name]?.startLine;
+
+      if (attributeLineNumber) {
+        lineNumberStart += attributeLineNumber - 1;
       }
+
       jsParser.parseString(attr.value, fileName, {
         lineNumberStart,
       });


### PR DESCRIPTION
A couple of fixes:

**embeddedJS**

Change way of extracting embedded JS to look for "#text" nodes, as serializer drops original line breaks and results with wrong line numbers

Such example was giving wrong line numbers:

```vue
<div>
  <button
    class="something"
    type="button"
  >
    {{ $gettext('Hello there!') }}
  </button>
</div>
```

**attributeEmbeddedJS**

Prevent scope leak for lineNumberStart variable, so result is correct for all attributes in tag, not only the first one

Such example was giving wrong line numbers:

```vue
<button
  class="something"
  v-text="$gettext('Hello there!')"
/>
```