### PR TITLE
fix: handle empty plural translations

### DIFF
--- a/src/translate.ts
+++ b/src/translate.ts
@@ -69,10 +69,18 @@ const translate = (language: Language) => ({
       if (arr.length === 1 && n === 1) {
         translationIndex = 0;
       }
-      if (!(arr as string[])[translationIndex]) {
+
+      const str = arr[translationIndex];
+      if (!str) {
+        // If the translation is empty, use the untranslated string.
+        if (str === "") {
+          return interp(untranslated, parameters);
+        }
+
         throw new Error(msgid + " " + translationIndex + " " + language.current + " " + n);
       }
-      return interp(arr[translationIndex], parameters);
+
+      return interp(str, parameters);
     };
 
     const getUntranslatedMsg = () => {

--- a/tests/json/translate.ts
+++ b/tests/json/translate.ts
@@ -22,6 +22,9 @@ export default {
       "": "Object",
       Context: "Object with context",
     },
+
+    "%{ orangeCount } orange": ["", "%{ orangeCount } oranges"],
+    "%{ appleCount } apple": ["1 apple", ""],
   },
   fr: {
     Answer: {

--- a/tests/translate.spec.ts
+++ b/tests/translate.spec.ts
@@ -78,6 +78,17 @@ describe("Translate tests", () => {
     translated = translate.getTranslation("Untranslated %{ n } item", 2, null, "Untranslated %{ n } items", "en_US");
     expect(translated).toEqual("Untranslated %{ n } items");
 
+    // Ensure that pluralization does not fail if the translation have empty strings for singural or plural form.
+    translated = translate.getTranslation("%{ orangeCount } orange", 1, null, "%{ orangeCount } oranges", "en_US");
+    expect(translated).toEqual("%{ orangeCount } orange");
+    translated = translate.getTranslation("%{ orangeCount } orange", 2, null, "%{ orangeCount } oranges", "en_US");
+    expect(translated).toEqual("%{ orangeCount } oranges");
+
+    translated = translate.getTranslation("%{ appleCount } apple", 1, null, "%{ appleCount } apples", "en_US");
+    expect(translated).toEqual("1 apple");
+    translated = translate.getTranslation("%{ appleCount } apple", 2, null, "%{ appleCount } apples", "en_US");
+    expect(translated).toEqual("%{ appleCount } apples");
+
     // Test plural message with multiple contexts (default context and 'Context'')
     translated = translate.getTranslation("%{ carCount } car (multiple contexts)", 1, null, null, "en_US");
     expect(translated).toEqual("1 car");


### PR DESCRIPTION
In case translation json has empty singular and/or plural strings in the array, the translation function will throw an error. 
This could potentionally prevent render of vue component.

getTranslationFromArray function is checking for translation string to be falsy value, so it will throw an error if the translation string is empty. According to gettext [manual](https://www.gnu.org/software/gettext/manual/html_node/Untranslated-Entries.html), empty strings should be treated as untranslated. 

This commit fixes by checking that translation string is falsy, but not string. For empty strings error is not thrown and untranslated string returned.