### PR TITLE
Allow to use an Ecmascript module as config in addition to CommonJS module file.

### DIFF
--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -32,6 +32,16 @@ module.exports = {
 };
 ```
 
+You can also use a `gettext.config.mjs` file with the Ecmascript module format:
+
+```js
+export default {
+  output: {
+    locales: ["en", "de"],
+  },
+}
+```
+
 Here are all the available configuration options and their defaults:
 
 ```js

--- a/docs/zh/extraction.md
+++ b/docs/zh/extraction.md
@@ -33,6 +33,16 @@ module.exports = {
 };
 ```
 
+您也可以使用带有 Ecmascript 模块格式的 `gettext.config.mjs` 文件：
+
+```js
+export default {
+  output: {
+    locales: ["en", "de"],
+  },
+}
+```
+
 下面列出所有配置选项和默认值：
 
 ```js

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -1,19 +1,19 @@
-import { cosmiconfigSync } from "cosmiconfig";
+import { cosmiconfig } from "cosmiconfig";
 import path from "path";
 import { GettextConfig, GettextConfigOptions } from "../src/typeDefs";
 
-export const loadConfig = (cliArgs?: { config?: string }): GettextConfig => {
+export const loadConfig = async (cliArgs?: { config?: string }): Promise<GettextConfig> => {
   const moduleName = "gettext";
-  const explorer = cosmiconfigSync(moduleName);
+  const explorer = cosmiconfig(moduleName);
 
   let configRes;
   if (cliArgs?.config) {
-    configRes = explorer.load(cliArgs.config);
+    configRes = await explorer.load(cliArgs.config);
     if (!configRes) {
       throw new Error(`Config not found: ${cliArgs.config}`);
     }
   } else {
-    configRes = explorer.search();
+    configRes = await explorer.search();
   }
 
   const config = configRes?.config as GettextConfigOptions;

--- a/scripts/gettext_compile.ts
+++ b/scripts/gettext_compile.ts
@@ -16,17 +16,15 @@ try {
   process.exit(1);
 }
 
-const config = loadConfig(options);
-
-console.info(`Language directory: ${chalk.blueBright(config.output.path)}`);
-console.info(`Locales: ${chalk.blueBright(config.output.locales)}`);
-console.info();
-
-const localesPaths = config.output.locales.map((loc) =>
-  config.output.flat ? path.join(config.output.path, `${loc}.po`) : path.join(config.output.path, `${loc}/app.po`),
-);
-
 (async () => {
+  const config = await loadConfig(options);
+  console.info(`Language directory: ${chalk.blueBright(config.output.path)}`);
+  console.info(`Locales: ${chalk.blueBright(config.output.locales)}`);
+  console.info();
+  const localesPaths = config.output.locales.map((loc) =>
+    config.output.flat ? path.join(config.output.path, `${loc}.po`) : path.join(config.output.path, `${loc}/app.po`),
+  );
+
   await fsPromises.mkdir(config.output.path, { recursive: true });
   const jsonRes = await compilePoFiles(localesPaths);
   console.info(`${chalk.green("Compiled json")}: ${chalk.grey(JSON.stringify(jsonRes))}`);

--- a/scripts/gettext_extract.ts
+++ b/scripts/gettext_extract.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { loadConfig } from "./config";
 import extractFromFiles from "./extract";
 import { execShellCommand } from "./utils";
+import { GettextConfig } from "../src/typeDefs";
 
 const optionDefinitions: OptionDefinition[] = [{ name: "config", alias: "c", type: String }];
 let options;
@@ -18,8 +19,6 @@ try {
   process.exit(1);
 }
 
-const config = loadConfig(options);
-
 const globPromise = (pattern: string) =>
   new Promise((resolve, reject) => {
     try {
@@ -31,7 +30,7 @@ const globPromise = (pattern: string) =>
     }
   });
 
-var getFiles = async () => {
+var getFiles = async (config: GettextConfig) => {
   const allFiles = await Promise.all(
     config.input?.include.map((pattern) => {
       const searchPath = path.join(config.input.path, pattern);
@@ -57,14 +56,15 @@ var getFiles = async () => {
   return filesFlat;
 };
 
-console.info(`Input directory: ${chalk.blueBright(config.input.path)}`);
-console.info(`Output directory: ${chalk.blueBright(config.output.path)}`);
-console.info(`Output POT file: ${chalk.blueBright(config.output.potPath)}`);
-console.info(`Locales: ${chalk.blueBright(config.output.locales)}`);
-console.info();
-
 (async () => {
-  const files = await getFiles();
+  const config = await loadConfig(options);
+  console.info(`Input directory: ${chalk.blueBright(config.input.path)}`);
+  console.info(`Output directory: ${chalk.blueBright(config.output.path)}`);
+  console.info(`Output POT file: ${chalk.blueBright(config.output.potPath)}`);
+  console.info(`Locales: ${chalk.blueBright(config.output.locales)}`);
+  console.info();
+
+  const files = await getFiles(config);
   console.info();
   files.forEach((f) => console.info(chalk.grey(f)));
   console.info();


### PR DESCRIPTION
`gettext.config.mjs` is now possible in addition to `gettext.config.js` or `gettext.config.cjs`.

This allows to import other Ecmascript modules for gettext dynamic configuration for instance.