### PR TITLE
Add option for --no-fuzzy-matching when running msgmerge

### DIFF
--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -85,6 +85,7 @@ module.exports = {
     flat: false, // don't create subdirectories for locales
     linguas: true, // create a LINGUAS file
     splitJson: false, // create separate json files for each locale. If used, jsonPath must end with a directory, not a file
+    fuzzyMatching: false, // do not fuzzy match strings when merging the POT file into the PO files
   },
 };
 ```

--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -85,7 +85,7 @@ module.exports = {
     flat: false, // don't create subdirectories for locales
     linguas: true, // create a LINGUAS file
     splitJson: false, // create separate json files for each locale. If used, jsonPath must end with a directory, not a file
-    fuzzyMatching: false, // do not fuzzy match strings when merging the POT file into the PO files
+    fuzzyMatching: false, // do not fuzzy match strings when merging the pot file into the po files
   },
 };
 ```

--- a/docs/zh/extraction.md
+++ b/docs/zh/extraction.md
@@ -85,6 +85,7 @@ module.exports = {
     flat: false, // 是否为每种语言单独创建一个文件夹
     linguas: true, // 创建一个 LINGUAS 文件
     splitJson: false, // 为每种语言生成一个 json 文件，如果为 true, jsonPath 应当是一个目录路径而不是一个文件路径
+    fuzzyMatching: false, // 将 pot 文件合并到 po 文件时不要模糊匹配字符串
   },
 };
 ```

--- a/gettext.config.js
+++ b/gettext.config.js
@@ -56,5 +56,6 @@ module.exports = {
     path: "./dev/language",
     locales: ["en_GB", "fr_FR", "it_IT", "zh_CN"],
     splitJson: false,
+    fuzzyMatching: true,
   },
 };

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -45,7 +45,6 @@ export const loadConfig = async (cliArgs?: { config?: string }): Promise<Gettext
       linguas: config.output?.linguas === undefined ? true : config.output.linguas,
       splitJson: config.output?.splitJson === undefined ? false : config.output.splitJson,
       fuzzyMatching: config.output?.fuzzyMatching === undefined ? true : config.output.fuzzyMatching,
-
     },
   };
 };

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -44,6 +44,8 @@ export const loadConfig = async (cliArgs?: { config?: string }): Promise<Gettext
       flat: config.output?.flat === undefined ? false : config.output.flat,
       linguas: config.output?.linguas === undefined ? true : config.output.linguas,
       splitJson: config.output?.splitJson === undefined ? false : config.output.splitJson,
+      fuzzyMatching: config.output?.fuzzyMatching === undefined ? true : config.output.fuzzyMatching,
+
     },
   };
 };

--- a/scripts/gettext_extract.ts
+++ b/scripts/gettext_extract.ts
@@ -77,7 +77,11 @@ var getFiles = async (config: GettextConfig) => {
     fs.mkdirSync(poDir, { recursive: true });
     const isFile = fs.existsSync(poFile) && fs.lstatSync(poFile).isFile();
     if (isFile) {
-      await execShellCommand(`msgmerge --lang=${loc} --update ${poFile} ${config.output.potPath}${config.output.fuzzyMatching ? '' : '--no-fuzzy-matching'} --backup=off`);
+      await execShellCommand(
+        `msgmerge --lang=${loc} --update ${poFile} ${config.output.potPath} ${
+          config.output.fuzzyMatching ? "" : "--no-fuzzy-matching"
+        } --backup=off`,
+      );
       console.info(`${chalk.green("Merged")}: ${chalk.blueBright(poFile)}`);
     } else {
       // https://www.gnu.org/software/gettext/manual/html_node/msginit-Invocation.html

--- a/scripts/gettext_extract.ts
+++ b/scripts/gettext_extract.ts
@@ -77,7 +77,7 @@ var getFiles = async (config: GettextConfig) => {
     fs.mkdirSync(poDir, { recursive: true });
     const isFile = fs.existsSync(poFile) && fs.lstatSync(poFile).isFile();
     if (isFile) {
-      await execShellCommand(`msgmerge --lang=${loc} --update ${poFile} ${config.output.potPath} --backup=off`);
+      await execShellCommand(`msgmerge --lang=${loc} --update ${poFile} ${config.output.potPath}${config.output.fuzzyMatching ? '' : '--no-fuzzy-matching'} --backup=off`);
       console.info(`${chalk.green("Merged")}: ${chalk.blueBright(poFile)}`);
     } else {
       // https://www.gnu.org/software/gettext/manual/html_node/msginit-Invocation.html

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -100,6 +100,7 @@ export interface GettextConfig {
     flat: boolean;
     linguas: boolean;
     splitJson: boolean;
+    fuzzyMatching: boolean;
   };
 }
 


### PR DESCRIPTION
Fuzzy matching when merging the POT file into the PO files causes translations to be 'guessed' when a similar translation exists, for my project i'd prefer these to be blank as I automate a pre-translation.

It's also quicker to process when fuzzy matching is turned off, especially with larger translation files.