### PR TITLE
fix exception on "template" elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "vue-gettext-compile": "./dist/bin/gettext_compile.js"
   },
   "scripts": {
+    "prepare": "npm run build",
     "docs": "vuepress dev docs",
     "docs:build": "vuepress build docs -d distDocs",
     "docs:extract": "node --loader ts-node/esm ./scripts/gettext_extract.ts",

--- a/scripts/embeddedJsExtractor.ts
+++ b/scripts/embeddedJsExtractor.ts
@@ -18,8 +18,14 @@ const getElementContent = (element: Element | Template, options: IContentOptions
   // text nodes within template tags don't get serialized properly, this is a hack
   if (element.tagName === "template") {
     const docFragment = treeAdapter.createDocumentFragment();
-    (element as Template).content.childNodes.forEach((childNode: Node) => {
-      treeAdapter.appendChild(docFragment, childNode);
+    let childNodes
+    if (typeof (element as Template).content === "undefined") {
+        childNodes = (element as Template).childNodes
+    } else {
+        childNodes = (element as Template).content.childNodes
+    }
+    childNodes.forEach((childNode: Node) => {
+        treeAdapter.appendChild(docFragment, childNode);
     });
     content = serialize(docFragment, {});
   }


### PR DESCRIPTION
This patch is over `2.4.0` (I tried `4.0.0-alpha-8` with too many broken things).

It fixes:
```
        element.content.childNodes.forEach(function (childNode) {
                        ^

TypeError: Cannot read properties of undefined (reading 'childNodes')
    at getElementContent (/home/vaab/dev/js/monujo/node_modules/vue3-gettext/dist/bin/gettext_extract.js:93:25)
    at /home/vaab/dev/js/monujo/node_modules/vue3-gettext/dist/bin/gettext_extract.js:112:26
    at HtmlParser.parseNode (/home/vaab/dev/js/monujo/node_modules/gettext-extractor/dist/html/parser.js:19:13)
```

When encountering this file `test.vue` with this content:

```
<template>
  <svg>
    <template v-for="x in [1, 2]">
    </template>
  </svg>
</template>
```

I'm aware that this is a quick workaround rather than a wise thoughtful patch.