### PR TITLE
Add vue-format flag if %{} interpolation is used

### DIFF
--- a/src/extract/parser.ts
+++ b/src/extract/parser.ts
@@ -3,10 +3,18 @@ import { Token, tokenize, TokenKind } from "./tokenizer.js";
 import { KeywordMapping } from "../typeDefs.js";
 import { assertIsDefined } from "../utilities.js";
 
+// Interpolation RegExp - matches Vue.js %{} syntax
+const INTERPOLATION_RE = /%\{((?:.|\n)+?)\}/g;
+
+function hasInterpolation(message: string): boolean {
+  return INTERPOLATION_RE.test(message);
+}
+
 type BaseMsg = { message: string; messagePlural?: string; context?: string };
 
 export type MsgInfo = BaseMsg & {
   lineNumber: number;
+  hasInterpolation: boolean;
 };
 
 type MsgInfoWithCharIdx = BaseMsg & { idx: number };
@@ -138,6 +146,8 @@ export function parseSrc(src: string, options?: { mapping?: KeywordMapping; over
     return {
       ...i,
       lineNumber: src.substring(0, info.idx).split("\n").length,
+      hasInterpolation:
+        hasInterpolation(info.message) || (info.messagePlural ? hasInterpolation(info.messagePlural) : false),
     };
   });
 }
@@ -152,6 +162,7 @@ export function makePO(fileName: string, msgs: MsgInfo[]): PO {
     item.msgid_plural = msg.messagePlural;
     item.msgctxt = msg.context;
     item.references = [`${fileName}:${msg.lineNumber}`];
+    item.flags["vue-format"] = msg.hasInterpolation;
     po.items.push(item);
   }
 

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -30,15 +30,18 @@ describe("parser", () => {
       {
         message: "Welcome, %{ name }",
         lineNumber: 6,
+        hasInterpolation: true,
       },
       {
         message: "asdf",
         lineNumber: 10,
+        hasInterpolation: false,
       },
       {
         lineNumber: 19,
         message: "%{count} book",
         messagePlural: "%{count} books",
+        hasInterpolation: true,
       },
     ]);
 
@@ -47,6 +50,7 @@ describe("parser", () => {
 msgstr \"\"
 
 #: testFile:6
+#, vue-format
 msgid \"Welcome, %{ name }\"
 msgstr \"\"
 
@@ -55,6 +59,7 @@ msgid \"asdf\"
 msgstr \"\"
 
 #: testFile:19
+#, vue-format
 msgid \"%{count} book\"
 msgid_plural \"%{count} books\"
 msgstr[0] \"\"
@@ -73,6 +78,7 @@ Line breaks\`)`),
         message: `Test
 With
 Line breaks`,
+        hasInterpolation: false,
       },
     ]);
   });
@@ -84,6 +90,7 @@ Line breaks`,
       {
         message: unicodeTestPage,
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
   });
@@ -93,6 +100,7 @@ Line breaks`,
       {
         message: `t'\`e"st`,
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
 
@@ -100,6 +108,7 @@ Line breaks`,
       {
         message: `t\'\`e"st`,
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
 
@@ -107,6 +116,7 @@ Line breaks`,
       {
         message: "t'`est",
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
 
@@ -115,6 +125,7 @@ Line breaks`,
         message: "t'`e\"st",
         messagePlural: `t'\`e"st`,
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
   });
@@ -124,6 +135,7 @@ Line breaks`,
       {
         message: `\\`,
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
   });
@@ -134,6 +146,7 @@ Line breaks`,
         message: `te(st)(()`,
         messagePlural: "test)(()",
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
   });
@@ -143,6 +156,7 @@ Line breaks`,
       {
         message: `test`,
         lineNumber: 1,
+        hasInterpolation: false,
       },
     ]);
   });
@@ -170,6 +184,7 @@ export default {
       {
         message: `%{fullName} wants to say hello`,
         lineNumber: 15,
+        hasInterpolation: true,
       },
     ]);
   });
@@ -198,6 +213,7 @@ export default {
       {
         message: `Hello there`,
         lineNumber: 16,
+        hasInterpolation: false,
       },
     ]);
   });


### PR DESCRIPTION
We test for interpolated values and assign the vue-format flag to these strings.

This adds support translation checks like
https://docs.weblate.org/en/latest/user/checks.html#vue-i18n-formatting

Thanks for checking this out!