### PR TITLE
fix: normalize exclude paths

### DIFF
--- a/scripts/gettext_extract.ts
+++ b/scripts/gettext_extract.ts
@@ -32,7 +32,7 @@ const getFiles = async (config: GettextConfig) => {
   );
   const excludeFiles = await Promise.all(
     config.input.exclude.map((pattern) => {
-      const searchPath = path.join(config.input.path, pattern);
+      const searchPath = path.join(config.input.path, pattern).replace(/\\/g, "/");
       console.info(`Excluding: ${chalk.blueBright(searchPath)}`);
       return glob(searchPath);
     }),


### PR DESCRIPTION
This fixes an issue on Windows when exclude patters cannot match anything due to mismatching slashes.

Relevant snippet I observed:
```
Searching: wwwroot/js/vue/**/*.js
Searching: wwwroot/js/vue/**/*.ts
Searching: wwwroot/js/vue/**/*.vue

Excluding: wwwroot\js\vue\vue.global.prod.js
Excluding: wwwroot\js\vue\vue-i18n.global*.js
Excluding: wwwroot\js\vue\dist\**
```