### PR TITLE
fix: remove `@vue/runtime-core` type augmentation

### DIFF
--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -141,7 +141,3 @@ interface GlobalTypes extends Pick<Language, "$gettext" | "$pgettext" | "$ngette
 declare module "vue" {
   interface ComponentCustomProperties extends GlobalTypes {}
 }
-
-declare module "@vue/runtime-core" {
-  interface ComponentCustomProperties extends GlobalTypes {}
-}


### PR DESCRIPTION
Augmenting `@vue/runtime-core` creates issues in Nuxt apps because it messes with Nuxt's own type augmentations, leading to type loss of all auto-imported things in Vue templates.

Also, augmenting global properties should be done via `declare module 'vue'`, as stated in [the docs](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties).