### PR TITLE
fix: externalize vue and runtime deps in library build

### DIFF
--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -1,8 +1,15 @@
 import { defineConfig } from "rolldown";
 import { dts } from "rolldown-plugin-dts";
+import pkg from "./package.json" with { type: "json" };
+
+// Externalize peer and runtime dependencies so consuming applications provide
+// their own copy (most importantly Vue - bundling it causes duplicate Vue
+// instances and broken reactivity in consumers).
+const external = [...Object.keys(pkg.peerDependencies ?? {}), ...Object.keys(pkg.dependencies ?? {})];
 
 export default defineConfig({
   input: "./src/index.ts",
+  external,
   plugins: [dts()],
   output: [{ dir: "dist", format: "es" }],
 });


### PR DESCRIPTION
The rolldown migration in d85c04b dropped the implicit externalization that tsup did by default, causing vue and other deps to be bundled into dist. This now breaks consumers with duplicate Vue instances and broken reactivity, so externalize peerDependencies and dependencies explicitly.

fixes https://github.com/jshmrtn/vue3-gettext/issues/89